### PR TITLE
Configuración de fuentes de ingreso

### DIFF
--- a/src/Cashflowio.Core/Cashflowio.Core.csproj
+++ b/src/Cashflowio.Core/Cashflowio.Core.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="1.2.9" />
     <PackageReference Include="FluentDateTime" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cashflowio.Core/Entities/Concept.cs
+++ b/src/Cashflowio.Core/Entities/Concept.cs
@@ -1,15 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Cashflowio.Core.Entities
 {
-    public class Concept : Transaction
+    public class Concept
     {
         public DayOfWeek PayDay { get; set; }
+        public double Amount { get; set; }
+        public string Description { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public Recurrence Recurrence { get; set; }
 
         public int DestinationId { get; set; }
-        public MoneyAccount Destination { get; set; }
 
-        public IEnumerable<DateTime> Dates { get; set; }
+        [JsonIgnore] public MoneyAccount Destination { get; set; }
+        [JsonIgnore] public IEnumerable<DateTime> Dates { get; set; }
     }
 }

--- a/src/Cashflowio.Core/Entities/Income.cs
+++ b/src/Cashflowio.Core/Entities/Income.cs
@@ -2,12 +2,7 @@
 {
     public class Income : Transaction
     {
-        public int SourceId { get; set; }
-        public Concept Source { get; set; }
-        
         public int DestinationId { get; set; }
         public MoneyAccount Destination { get; set; }
-        public bool IsFixed { get; set; }
     }
-    
 }

--- a/src/Cashflowio.Core/Entities/IncomeSource.cs
+++ b/src/Cashflowio.Core/Entities/IncomeSource.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Cashflowio.Core.Extensions;
+using Newtonsoft.Json;
 
 namespace Cashflowio.Core.Entities
 {
@@ -9,54 +10,38 @@ namespace Cashflowio.Core.Entities
     {
         public IncomeSource()
         {
+            Currency = Entities.Currency.MXN.ToString();
         }
 
-        private IncomeSource(string name, Currency currency)
+        public IncomeSource(string name, Currency currency = Entities.Currency.MXN)
         {
             Name = name;
             Currency = currency.ToString();
         }
 
-        public DateTime StartDate { get; set; }
-        public DateTime? EndDate { get; set; }
-        public Recurrence Recurrence { get; set; }
-        public bool IsFixed { get; set; } = true;
+        public string Concepts { get; set; }
 
-        public List<Concept> Concepts { get; set; } = new List<Concept>();
+        public List<Concept> GeneratedConcepts => JsonConvert.DeserializeObject<List<Concept>>(Concepts);
 
-        public static IncomeSource Fixed(string name, Currency currency = Entities.Currency.MXN)
+        public List<Income> GenerateIncome()
         {
-            return new IncomeSource(name, currency) {IsFixed = true};
-        }
-
-        public static IncomeSource Variable(string name, Currency currency = Entities.Currency.MXN)
-        {
-            return new IncomeSource(name, currency) {IsFixed = false};
-        }
-
-        public List<Income> MakeIncome()
-        {
-            var endDate = EndDate ?? DateTime.Now;
-
-            Concepts.ToList().ForEach(concept =>
+            var makeIncome = new List<Income>();
+            foreach (var concept in GeneratedConcepts)
             {
-                var startDate = StartDate.GetNextWeekday(concept.PayDay);
-                concept.Dates = startDate.RangeTo(endDate, Recurrence);
-            });
+                var endDate = concept.EndDate ?? DateTime.Now;
+                var startDate = concept.StartDate.GetNextWeekday(concept.PayDay);
+                concept.Dates = startDate.RangeTo(endDate, concept.Recurrence);
 
-            return Concepts.Select(concept =>
-            {
-                return concept.Dates.Select(date => new Income
+                makeIncome.AddRange(concept.Dates.Select(date => new Income
                 {
                     Date = date,
                     Amount = concept.Amount,
-                    IsFixed = IsFixed,
                     Description = concept.Description,
-                    Source = concept,
-                    Destination = concept.Destination,
-                    ExchangeRate = concept.ExchangeRate
-                });
-            }).SelectMany(x => x).ToList();
+                    Destination = concept.Destination
+                }));
+            }
+
+            return makeIncome;
         }
     }
 }

--- a/src/Cashflowio.Infrastructure/Data/AppDbContext.cs
+++ b/src/Cashflowio.Infrastructure/Data/AppDbContext.cs
@@ -11,7 +11,7 @@ namespace Cashflowio.Infrastructure.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Concept>().Ignore(x => x.Dates);
+            modelBuilder.Entity<IncomeSource>().Ignore(x => x.GeneratedConcepts);
         }
 
         public DbSet<RawTransaction> RawTransactions { get; set; }
@@ -19,7 +19,6 @@ namespace Cashflowio.Infrastructure.Data
         public DbSet<ExchangeRate> ExchangeRates { get; set; }
         public DbSet<MoneyAccount> MoneyAccounts { get; set; }
         public DbSet<IncomeSource> IncomeSources { get; set; }
-        public DbSet<Concept> Concepts { get; set; }
         public DbSet<Transfer> Transfers { get; set; }
     }
 }

--- a/src/Cashflowio.Infrastructure/Migrations/20191124025742_EliminarConceptos.Designer.cs
+++ b/src/Cashflowio.Infrastructure/Migrations/20191124025742_EliminarConceptos.Designer.cs
@@ -4,14 +4,16 @@ using Cashflowio.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Cashflowio.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20191124025742_EliminarConceptos")]
+    partial class EliminarConceptos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Cashflowio.Infrastructure/Migrations/20191124025742_EliminarConceptos.cs
+++ b/src/Cashflowio.Infrastructure/Migrations/20191124025742_EliminarConceptos.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Cashflowio.Infrastructure.Migrations
+{
+    public partial class EliminarConceptos : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Concepts");
+
+            migrationBuilder.DropColumn(
+                name: "EndDate",
+                table: "IncomeSources");
+
+            migrationBuilder.DropColumn(
+                name: "IsFixed",
+                table: "IncomeSources");
+
+            migrationBuilder.DropColumn(
+                name: "Recurrence",
+                table: "IncomeSources");
+
+            migrationBuilder.DropColumn(
+                name: "StartDate",
+                table: "IncomeSources");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Concepts",
+                table: "IncomeSources",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Concepts",
+                table: "IncomeSources");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "EndDate",
+                table: "IncomeSources",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsFixed",
+                table: "IncomeSources",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Recurrence",
+                table: "IncomeSources",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StartDate",
+                table: "IncomeSources",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.CreateTable(
+                name: "Concepts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Amount = table.Column<double>(type: "float", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    DestinationId = table.Column<int>(type: "int", nullable: false),
+                    ExchangeRateId = table.Column<int>(type: "int", nullable: true),
+                    IncomeSourceId = table.Column<int>(type: "int", nullable: true),
+                    PayDay = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Concepts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Concepts_MoneyAccounts_DestinationId",
+                        column: x => x.DestinationId,
+                        principalTable: "MoneyAccounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Concepts_ExchangeRates_ExchangeRateId",
+                        column: x => x.ExchangeRateId,
+                        principalTable: "ExchangeRates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Concepts_IncomeSources_IncomeSourceId",
+                        column: x => x.IncomeSourceId,
+                        principalTable: "IncomeSources",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Concepts_DestinationId",
+                table: "Concepts",
+                column: "DestinationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Concepts_ExchangeRateId",
+                table: "Concepts",
+                column: "ExchangeRateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Concepts_IncomeSourceId",
+                table: "Concepts",
+                column: "IncomeSourceId");
+        }
+    }
+}

--- a/src/Cashflowio.Web/Controllers/IncomeSourceController.cs
+++ b/src/Cashflowio.Web/Controllers/IncomeSourceController.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq;
+using Cashflowio.Core.Entities;
+using Cashflowio.Core.Interfaces;
+using Cashflowio.Web.Controllers.Abstractions;
+
+namespace Cashflowio.Web.Controllers
+{
+    public class IncomeSourceController : CrudController<IncomeSource>
+    {
+        public IncomeSourceController(IRepository repository) : base(repository)
+        {
+            FilterBy = (incomeSource, moneyAccountId) =>
+                incomeSource.GeneratedConcepts.All(x => x.DestinationId == moneyAccountId);
+        }
+    }
+}

--- a/src/Cashflowio.Web/Views/IncomeSource/Index.cshtml
+++ b/src/Cashflowio.Web/Views/IncomeSource/Index.cshtml
@@ -1,0 +1,35 @@
+﻿@using Cashflowio.Core.Interfaces
+@using Newtonsoft.Json
+@inject IRepository Repository
+@{
+    ViewData["Title"] = "Income Source";
+    var concepts = JsonConvert.SerializeObject(new List<Concept>
+    {
+        new Concept
+        {
+            PayDay = DayOfWeek.Friday,
+            Recurrence = Recurrence.Weekly,
+            Amount = 3000,
+            Description = "Sueldo",
+            DestinationId = ViewBag.Id,
+            StartDate = DateTime.Today,
+            EndDate = DateTime.Now
+        }
+    });
+}
+
+<ejs-grid id="Grid" toolbar="@(new List<string> {"Add", "Edit", "Delete"})"
+          height="555" width="auto" allowTextWrap="true" allowPaging="true" allowSorting="true">
+    <e-grid-pagesettings pageSize="50" pageSizes="@(new[] {"10", "50", "100", "200", "500", "1000", "All"})"></e-grid-pagesettings>
+    <e-grid-filtersettings type="Excel"></e-grid-filtersettings>
+    <e-grid-sortsettings columns="@(new[] {new {field = "name", direction = "Ascending"}})"></e-grid-sortsettings>
+    <e-data-manager adaptor="UrlAdaptor" url="@Url.Action("DataSource")/@ViewBag.Id" crudUrl="@Url.Action("Crud")"></e-data-manager>
+    <e-grid-editSettings allowAdding="true" allowDeleting="true" allowEditing="true" mode="Dialog" showDeleteConfirmDialog="true"></e-grid-editSettings>
+    <e-grid-pagesettings pageCount="10"></e-grid-pagesettings>
+    <e-grid-columns>
+        <e-grid-column field="id" visible="false" isPrimaryKey="true" isIdentity="true"></e-grid-column>
+        <e-grid-column field="name" headerText="Name" validationRules="@(new {required = true})" width="170"></e-grid-column>
+        @* <e-grid-column field="currency" headerText="Currency" validationRules="@(new {required = true})" width="170"></e-grid-column> *@
+        <e-grid-column field="concepts" headerText="Concepts" type="text" defaultValue="@concepts" validationRules="@(new {required = true})" width="170"></e-grid-column>
+    </e-grid-columns>
+</ejs-grid>

--- a/src/Cashflowio.Web/Views/MoneyAccount/Index.cshtml
+++ b/src/Cashflowio.Web/Views/MoneyAccount/Index.cshtml
@@ -16,9 +16,14 @@
         DataSource = new SelectList(Enum.GetNames(typeof(Currency)).Select(x => new {Value = x, Text = x}), "Value", "Text"),
         Query = "new ej.data.Query()", AllowFiltering = true, Fields = new Syncfusion.EJ2.DropDowns.DropDownListFieldSettings {Value = "Value", Text = "Text"}
     };
+
+    var commands = new List<object>
+    {
+        new {title = "Income Sources", buttonOption = new {iconCss = "fas fa-arrow-circle-down fa-fw", cssClass = "e-success e-income-source"}}
+    };
 }
 
-<ejs-grid id="Grid" toolbar="@(new List<string> {"Add", "Edit", "Delete"})"
+<ejs-grid id="Grid" toolbar="@(new List<string> {"Add", "Edit", "Delete"})" dataBound="dataBound"
           height="555" width="auto" allowTextWrap="true" allowPaging="true" allowSorting="true">
     <e-grid-pagesettings pageSize="50" pageSizes="@(new[] {"10", "50", "100", "200", "500", "1000", "All"})"></e-grid-pagesettings>
     <e-grid-filtersettings type="Excel"></e-grid-filtersettings>
@@ -31,5 +36,20 @@
         <e-grid-column field="name" headerText="Name" validationRules="@(new {required = true})" width="170"></e-grid-column>
         <e-grid-column field="type" headerText="Type" editType="dropdownedit" edit="new {@params = types }" width="120"></e-grid-column>
         <e-grid-column field="currency" headerText="Currency" editType="dropdownedit" edit="new {@params = currencies }" width="120"></e-grid-column>
+        <e-grid-column commands="@commands" width="100"></e-grid-column>
     </e-grid-columns>
 </ejs-grid>
+
+@section scripts{
+    <script>
+     function dataBound(e) {  
+            var grid = document.getElementsByClassName("e-grid")[0];
+            grid.addEventListener('click', function (e) {         
+                if (e.target.classList.contains('e-income-source')) {                     
+                    var primaryKeyValue = e.target.closest("tr").childNodes[0].innerHTML; 
+                    window.location.href = "@Url.Action("Index", "IncomeSource")/" + primaryKeyValue;
+                }  
+            });
+     }  
+</script>
+}

--- a/tests/Cashflowio.Tests/Core/IncomeSourceTests.cs
+++ b/tests/Cashflowio.Tests/Core/IncomeSourceTests.cs
@@ -3,52 +3,40 @@ using System.Collections.Generic;
 using System.Linq;
 using Cashflowio.Core.Entities;
 using FluentDateTime;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Cashflowio.Tests.Core
 {
     public class IncomeSourceTests
     {
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SetupAndGetIncome(bool isFixed)
+        [Fact]
+        public void SetupAndGetIncome()
         {
-            var incomeSource = isFixed ? IncomeSource.Fixed("Monobits") : IncomeSource.Variable("Monobits");
-
-            var today = DateTime.Today;
-            incomeSource.StartDate = today.FirstDayOfMonth();
-            incomeSource.EndDate = today.LastDayOfMonth();
-            incomeSource.Recurrence = Recurrence.Weekly;
-            incomeSource.Concepts = new List<Concept>
+            var dateOfReference = new DateTime(2019, 11, 1);
+            var concepts = JsonConvert.SerializeObject(new List<Concept>
             {
                 new Concept
                 {
-                    Amount = 3300,
-                    Destination = FakeRepository.First(AccountType.Debit),
-                    PayDay = DayOfWeek.Thursday,
-                    Description = "Sueldo"
-                },
-                new Concept
-                {
-                    Amount = 700,
+                    Amount = 4200,
                     Destination = FakeRepository.First(AccountType.Debit),
                     PayDay = DayOfWeek.Friday,
-                    Description = "Sueldo"
-                },
-                new Concept
-                {
-                    Amount = 200,
-                    Destination = FakeRepository.First(AccountType.Cash),
-                    PayDay = DayOfWeek.Friday,
-                    Description = "Sueldo"
+                    Description = "Sueldo",
+                    StartDate = dateOfReference.FirstDayOfMonth(),
+                    EndDate = dateOfReference.LastDayOfMonth(),
+                    Recurrence = Recurrence.Weekly
                 }
+            });
+
+            var incomeSource = new IncomeSource("Monobits")
+            {
+                Concepts = concepts
             };
 
-            var incomes = incomeSource.MakeIncome();
+            var incomes = incomeSource.GenerateIncome();
 
-            Assert.Equal(14, incomes.Count);
-            Assert.True(incomes.All(x => x.IsFixed == isFixed));
+            Assert.Equal(5, incomes.Count);
+            Assert.True(incomes.All(x => x.Date.DayOfWeek == DayOfWeek.Friday));
         }
     }
 }


### PR DESCRIPTION
Agregar enlace desde cuentas de dinero a fuente de ingresos
Hacer migración para mover información a otra tabla
Simplificar el guardado de múltiples conceptos de una sola fuente de ingreso en formato JSON para guardarlo como un listado que construye en memoria para poder generar los ingresos correspondientes
Cátalogo básico de fuentes de ingreso